### PR TITLE
Add company name availability search plugin

### DIFF
--- a/wp-content/plugins/company-name-search/README.md
+++ b/wp-content/plugins/company-name-search/README.md
@@ -1,0 +1,53 @@
+# Company Name Availability Search
+
+A WordPress plugin that lets site visitors check whether a company name appears to be available. The plugin offers a shortcode-powered search form, a REST API endpoint, and a configurable data source.
+
+## Features
+
+- **Frontend search form** using the `[company_name_search]` shortcode.
+- **AJAX-powered experience** that leverages the WordPress REST API.
+- **Configurable data sources**: a bundled sample dataset or live results from the OpenCorporates API.
+- **Caching support** to avoid repeating the same remote lookups.
+- **Settings page** under *Settings → Company Name Search* for managing configuration.
+
+## Installation
+
+1. Upload the `company-name-search` folder to your site's `wp-content/plugins/` directory.
+2. Activate the plugin through the WordPress admin dashboard.
+3. Navigate to *Settings → Company Name Search* to adjust the data source and optional OpenCorporates options.
+4. Add the `[company_name_search]` shortcode to any post, page, or block editor shortcode block.
+
+## Shortcode Options
+
+| Attribute | Description | Default |
+|-----------|-------------|---------|
+| `title`   | Heading displayed above the search form. | `Check company name availability` |
+
+Example usage:
+
+```
+[company_name_search title="Find a company name"]
+```
+
+## Data Sources
+
+### Bundled Sample Data
+
+The plugin ships with a JSON file containing a handful of fictional company names. This mode is ideal for offline demos and development environments without internet access.
+
+### OpenCorporates API
+
+When the OpenCorporates data source is selected, the plugin sends a search request to `https://api.opencorporates.com/v0.4/companies/search` and displays the returned matches. Optionally provide an API token and a country code to refine the results.
+
+> **Note:** Network access is required for OpenCorporates lookups. If the remote request fails, users will see an error message.
+
+## Development
+
+- JavaScript assets are located in `assets/js/` and styles in `assets/css/`.
+- The REST endpoint is registered at `/wp-json/company-name-search/v1/check`.
+- Local search results can be filtered with the `company_name_search_local_companies` hook.
+- Final responses can be modified with the `company_name_search_result` filter.
+
+## License
+
+GPL-2.0-or-later

--- a/wp-content/plugins/company-name-search/assets/css/company-name-search.css
+++ b/wp-content/plugins/company-name-search/assets/css/company-name-search.css
@@ -1,0 +1,126 @@
+.company-name-search {
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+    padding: 24px;
+    background: #fff;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+}
+
+.company-name-search__title {
+    margin-top: 0;
+    margin-bottom: 16px;
+    font-size: 1.5rem;
+}
+
+.company-name-search__form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.company-name-search__input {
+    flex: 1 1 240px;
+    padding: 10px 12px;
+    border: 1px solid #7e8993;
+    border-radius: 3px;
+    font-size: 1rem;
+}
+
+.company-name-search__button {
+    background-color: #2271b1;
+    border: none;
+    border-radius: 3px;
+    color: #fff;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 600;
+    padding: 10px 16px;
+    transition: background-color 0.2s ease-in-out;
+}
+
+.company-name-search__button:hover,
+.company-name-search__button:focus {
+    background-color: #135e96;
+    outline: none;
+}
+
+.company-name-search__spinner {
+    width: 32px;
+    height: 32px;
+    border: 3px solid rgba(34, 113, 177, 0.2);
+    border-top-color: #2271b1;
+    border-radius: 50%;
+    animation: company-name-search-spin 1s linear infinite;
+    margin-bottom: 16px;
+}
+
+@keyframes company-name-search-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.company-name-search__status {
+    font-weight: 600;
+    margin-bottom: 12px;
+}
+
+.company-name-search__status--available {
+    color: #008a20;
+}
+
+.company-name-search__status--unavailable {
+    color: #d63638;
+}
+
+.company-name-search__status--error {
+    color: #d63638;
+}
+
+.company-name-search__matches-title {
+    font-size: 1.125rem;
+    margin: 16px 0 8px;
+}
+
+.company-name-search__matches {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 16px;
+}
+
+.company-name-search__match {
+    padding: 12px 0;
+    border-bottom: 1px solid #dcdcde;
+}
+
+.company-name-search__match:last-child {
+    border-bottom: none;
+}
+
+.company-name-search__match-name {
+    display: block;
+    font-weight: 600;
+}
+
+.company-name-search__match-details,
+.company-name-search__match-source {
+    display: block;
+    font-size: 0.875rem;
+    color: #50575e;
+    margin-top: 4px;
+}
+
+.company-name-search__match-source {
+    font-style: italic;
+}
+
+.company-name-search__no-results {
+    color: #50575e;
+    font-style: italic;
+}
+
+.company-name-search__message {
+    margin-top: 12px;
+    color: #2c3338;
+}

--- a/wp-content/plugins/company-name-search/assets/js/company-name-search.js
+++ b/wp-content/plugins/company-name-search/assets/js/company-name-search.js
@@ -1,0 +1,213 @@
+(function () {
+    'use strict';
+
+    const data = window.CompanyNameSearch || null;
+
+    if (!data) {
+        return;
+    }
+
+    const escapeHTML = (value) => {
+        if (value === null || value === undefined) {
+            return '';
+        }
+
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+    };
+
+    const createMatchList = (matches, strings) => {
+        if (!Array.isArray(matches) || matches.length === 0) {
+            return '<p class="company-name-search__no-results">' + escapeHTML(strings.noMatches) + '</p>';
+        }
+
+        let list = '<h4 class="company-name-search__matches-title">' + escapeHTML(strings.similarTitle) + '</h4>';
+        list += '<ul class="company-name-search__matches">';
+
+        matches.forEach((match) => {
+            if (!match || !match.name) {
+                return;
+            }
+
+            const name = escapeHTML(match.name);
+            let details = '';
+
+            if (match.company_number) {
+                details += '<span class="company-name-search__match-number">' + escapeHTML(match.company_number) + '</span>';
+            }
+
+            if (match.status) {
+                if (details) {
+                    details += ' · ';
+                }
+
+                details += '<span class="company-name-search__match-status">' + escapeHTML(match.status) + '</span>';
+            }
+
+            if (match.jurisdiction_code) {
+                if (details) {
+                    details += ' · ';
+                }
+
+                details += '<span class="company-name-search__match-jurisdiction">' + escapeHTML(String(match.jurisdiction_code).toUpperCase()) + '</span>';
+            }
+
+            if (match.registry_url) {
+                const registryUrl = escapeHTML(match.registry_url);
+                if (registryUrl) {
+                    details += ' · <a class="company-name-search__match-link" target="_blank" rel="noopener" href="' + registryUrl + '">' + escapeHTML(strings.registryLink || 'Registry') + '</a>';
+                }
+            }
+
+            let item = '<li class="company-name-search__match"><span class="company-name-search__match-name">' + name + '</span>';
+
+            if (details) {
+                item += '<span class="company-name-search__match-details">' + details + '</span>';
+            }
+
+            if (match.source) {
+                item += '<span class="company-name-search__match-source">' + escapeHTML(match.source) + '</span>';
+            }
+
+            item += '</li>';
+            list += item;
+        });
+
+        list += '</ul>';
+
+        return list;
+    };
+
+    const setLoadingState = (container, isLoading, strings) => {
+        const spinner = container.querySelector('.company-name-search__spinner');
+        const results = container.querySelector('.company-name-search__results');
+
+        if (isLoading) {
+            if (spinner) {
+                spinner.removeAttribute('hidden');
+                spinner.setAttribute('aria-hidden', 'false');
+            }
+            if (results) {
+                results.innerHTML = '<p class="company-name-search__status">' + escapeHTML(strings.loading) + '</p>';
+            }
+        } else if (spinner) {
+            spinner.setAttribute('hidden', 'hidden');
+            spinner.setAttribute('aria-hidden', 'true');
+        }
+    };
+
+    const renderResult = (container, response, strings) => {
+        const results = container.querySelector('.company-name-search__results');
+
+        if (!results) {
+            return;
+        }
+
+        if (!response || typeof response.available === 'undefined') {
+            results.innerHTML = '<p class="company-name-search__status company-name-search__status--error">' + escapeHTML(strings.error) + '</p>';
+            return;
+        }
+
+        const available = Boolean(response.available);
+        const statusClass = available ? 'company-name-search__status--available' : 'company-name-search__status--unavailable';
+        const message = available ? strings.available : strings.unavailable;
+
+        let html = '<p class="company-name-search__status ' + statusClass + '">' + escapeHTML(message) + '</p>';
+
+        if (response.matches && response.matches.length) {
+            html += createMatchList(response.matches, strings);
+        } else if (!available) {
+            html += '<p class="company-name-search__no-results">' + escapeHTML(strings.noMatches) + '</p>';
+        }
+
+        if (response.message) {
+            html += '<p class="company-name-search__message">' + escapeHTML(response.message) + '</p>';
+        }
+
+        results.innerHTML = html;
+    };
+
+    const renderError = (container, error, strings) => {
+        const results = container.querySelector('.company-name-search__results');
+
+        if (results) {
+            const message = (error && error.message) ? error.message : strings.error;
+            results.innerHTML = '<p class="company-name-search__status company-name-search__status--error">' + escapeHTML(message) + '</p>';
+        }
+    };
+
+    const handleSubmit = (event) => {
+        event.preventDefault();
+
+        const form = event.currentTarget;
+        const container = form.closest('[data-company-name-search]');
+
+        if (!container) {
+            return;
+        }
+
+        const input = container.querySelector('.company-name-search__input');
+        const strings = data.strings;
+
+        if (!input) {
+            return;
+        }
+
+        const value = input.value.trim();
+
+        if (!value) {
+            renderError(container, { message: strings.emptyQuery }, strings);
+            return;
+        }
+
+        setLoadingState(container, true, strings);
+
+        const url = data.restUrl + (data.restUrl.includes('?') ? '&' : '?') + 'name=' + encodeURIComponent(value);
+
+        fetch(url, {
+            method: 'GET',
+            headers: {
+                'X-WP-Nonce': data.nonce,
+                'Accept': 'application/json'
+            }
+        })
+            .then((response) => {
+                if (!response.ok) {
+                    return response.json().catch(() => ({})).then((payload) => {
+                        const message = payload && payload.message ? payload.message : strings.error;
+                        throw new Error(message);
+                    });
+                }
+                return response.json();
+            })
+            .then((payload) => {
+                setLoadingState(container, false, strings);
+                renderResult(container, payload, strings);
+            })
+            .catch((error) => {
+                setLoadingState(container, false, strings);
+                renderError(container, error, strings);
+            });
+    };
+
+    const init = () => {
+        const containers = document.querySelectorAll('[data-company-name-search]');
+
+        containers.forEach((container) => {
+            const form = container.querySelector('.company-name-search__form');
+            if (form) {
+                form.addEventListener('submit', handleSubmit);
+            }
+        });
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/wp-content/plugins/company-name-search/company-name-search.php
+++ b/wp-content/plugins/company-name-search/company-name-search.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Plugin Name:       Company Name Availability Search
+ * Plugin URI:        https://example.com/company-name-search
+ * Description:       Provides a front-end search experience to help users determine if a company name appears to be available.
+ * Version:           1.0.0
+ * Requires at least: 5.8
+ * Requires PHP:      7.4
+ * Author:            OpenAI Assistant
+ * License:           GPL-2.0-or-later
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+ * Text Domain:       company-name-search
+ * Domain Path:       /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+
+define( 'COMPANY_NAME_SEARCH_VERSION', '1.0.0' );
+define( 'COMPANY_NAME_SEARCH_PLUGIN_FILE', __FILE__ );
+define( 'COMPANY_NAME_SEARCH_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'COMPANY_NAME_SEARCH_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+require_once COMPANY_NAME_SEARCH_PLUGIN_DIR . 'includes/class-company-name-search-plugin.php';
+require_once COMPANY_NAME_SEARCH_PLUGIN_DIR . 'includes/class-company-name-search-api.php';
+require_once COMPANY_NAME_SEARCH_PLUGIN_DIR . 'includes/class-company-name-search-rest.php';
+
+/**
+ * Returns the main plugin instance.
+ *
+ * @return Company_Name_Search_Plugin
+ */
+function company_name_search_plugin() {
+return Company_Name_Search_Plugin::instance();
+}
+
+company_name_search_plugin();
+
+register_activation_hook( __FILE__, array( 'Company_Name_Search_Plugin', 'activate' ) );
+register_deactivation_hook( __FILE__, array( 'Company_Name_Search_Plugin', 'deactivate' ) );

--- a/wp-content/plugins/company-name-search/data/sample-companies.json
+++ b/wp-content/plugins/company-name-search/data/sample-companies.json
@@ -1,0 +1,72 @@
+[
+    {
+        "name": "Acme Corporation",
+        "company_number": "ACME0001",
+        "jurisdiction_code": "us_de",
+        "status": "Active",
+        "incorporation_date": "1995-04-12"
+    },
+    {
+        "name": "Globex Corporation",
+        "company_number": "GLOBEX42",
+        "jurisdiction_code": "us_nv",
+        "status": "Active",
+        "incorporation_date": "2001-09-01"
+    },
+    {
+        "name": "Stark Industries",
+        "company_number": "STARK007",
+        "jurisdiction_code": "us_de",
+        "status": "Active",
+        "incorporation_date": "1974-08-19"
+    },
+    {
+        "name": "Wayne Enterprises",
+        "company_number": "WAYNEBAT",
+        "jurisdiction_code": "us_de",
+        "status": "Active",
+        "incorporation_date": "1985-10-31"
+    },
+    {
+        "name": "Wonka Industries",
+        "company_number": "WONKA123",
+        "jurisdiction_code": "gb",
+        "status": "Dissolved",
+        "incorporation_date": "1964-02-01"
+    },
+    {
+        "name": "Soylent Corporation",
+        "company_number": "SOYLENT02",
+        "jurisdiction_code": "us_ca",
+        "status": "Active",
+        "incorporation_date": "1973-03-15"
+    },
+    {
+        "name": "Tyrell Corporation",
+        "company_number": "TYRELL09",
+        "jurisdiction_code": "us_ca",
+        "status": "Inactive",
+        "incorporation_date": "2019-11-20"
+    },
+    {
+        "name": "Hooli",
+        "company_number": "HOOLI001",
+        "jurisdiction_code": "us_ca",
+        "status": "Active",
+        "incorporation_date": "2010-06-10"
+    },
+    {
+        "name": "Initech",
+        "company_number": "INITEC01",
+        "jurisdiction_code": "us_tx",
+        "status": "Active",
+        "incorporation_date": "1991-01-15"
+    },
+    {
+        "name": "Pied Piper",
+        "company_number": "PIEDP001",
+        "jurisdiction_code": "us_ca",
+        "status": "Active",
+        "incorporation_date": "2014-03-01"
+    }
+]

--- a/wp-content/plugins/company-name-search/includes/class-company-name-search-api.php
+++ b/wp-content/plugins/company-name-search/includes/class-company-name-search-api.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * Handles company availability lookups.
+ *
+ * @package Company_Name_Search
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Provides search helpers for different data sources.
+ */
+class Company_Name_Search_API {
+    /**
+     * Parent plugin instance.
+     *
+     * @var Company_Name_Search_Plugin
+     */
+    protected $plugin;
+
+    /**
+     * Cached local company data.
+     *
+     * @var array|null
+     */
+    protected $local_companies = null;
+
+    /**
+     * Constructor.
+     *
+     * @param Company_Name_Search_Plugin $plugin Plugin instance.
+     */
+    public function __construct( Company_Name_Search_Plugin $plugin ) {
+        $this->plugin = $plugin;
+    }
+
+    /**
+     * Performs a search for the given company name.
+     *
+     * @param string $name Company name.
+     *
+     * @return array|WP_Error
+     */
+    public function search( $name ) {
+        $name = trim( wp_unslash( $name ) );
+
+        if ( '' === $name ) {
+            return new WP_Error(
+                'company_name_search_empty',
+                __( 'Please provide a company name to search.', 'company-name-search' ),
+                array( 'status' => 400 )
+            );
+        }
+
+        $settings = $this->plugin->get_settings();
+        $cache_key = 'company_name_search_' . md5( strtolower( $settings['data_source'] . '|' . $name ) );
+        $cached    = get_transient( $cache_key );
+
+        if ( false !== $cached ) {
+            return $cached;
+        }
+
+        if ( 'opencorporates' === $settings['data_source'] ) {
+            $result = $this->search_opencorporates( $name, $settings );
+        } else {
+            $result = $this->search_local( $name );
+        }
+
+        if ( ! is_wp_error( $result ) ) {
+            $expiration = (int) $settings['cache_duration'];
+            if ( $expiration > 0 ) {
+                set_transient( $cache_key, $result, $expiration );
+            }
+        }
+
+        /**
+         * Filters the search result before it is returned.
+         *
+         * @param array|WP_Error $result The result array or error.
+         * @param string         $name   The company name searched for.
+         */
+        return apply_filters( 'company_name_search_result', $result, $name );
+    }
+
+    /**
+     * Returns the bundled local companies data.
+     *
+     * @return array
+     */
+    protected function get_local_companies() {
+        if ( null !== $this->local_companies ) {
+            return $this->local_companies;
+        }
+
+        $data = array();
+        $path = COMPANY_NAME_SEARCH_PLUGIN_DIR . 'data/sample-companies.json';
+
+        if ( file_exists( $path ) && is_readable( $path ) ) {
+            $contents = file_get_contents( $path );
+            if ( $contents ) {
+                $decoded = json_decode( $contents, true );
+                if ( is_array( $decoded ) ) {
+                    $data = $decoded;
+                }
+            }
+        }
+
+        $this->local_companies = apply_filters( 'company_name_search_local_companies', $data );
+
+        return $this->local_companies;
+    }
+
+    /**
+     * Performs a search against the bundled local dataset.
+     *
+     * @param string $name Company name.
+     *
+     * @return array
+     */
+    protected function search_local( $name ) {
+        $companies     = $this->get_local_companies();
+        $matches       = array();
+        $has_exact_hit = false;
+
+        foreach ( $companies as $company ) {
+            if ( is_array( $company ) ) {
+                $company_name = isset( $company['name'] ) ? $company['name'] : '';
+            } else {
+                $company_name = (string) $company;
+                $company      = array( 'name' => $company_name );
+            }
+
+            if ( '' === $company_name ) {
+                continue;
+            }
+
+            if ( 0 === strcasecmp( $company_name, $name ) ) {
+                $has_exact_hit = true;
+            }
+
+            if ( false !== stripos( $company_name, $name ) ) {
+                $matches[] = array(
+                    'name'               => $company_name,
+                    'company_number'     => isset( $company['company_number'] ) ? $company['company_number'] : '',
+                    'jurisdiction_code'  => isset( $company['jurisdiction_code'] ) ? $company['jurisdiction_code'] : '',
+                    'status'             => isset( $company['status'] ) ? $company['status'] : '',
+                    'incorporation_date' => isset( $company['incorporation_date'] ) ? $company['incorporation_date'] : '',
+                    'source'             => __( 'Bundled sample data', 'company-name-search' ),
+                );
+            }
+        }
+
+        $response = array(
+            'query'      => $name,
+            'available'  => ! $has_exact_hit,
+            'source'     => 'local',
+            'matches'    => $matches,
+            'fetched_at' => current_time( 'mysql' ),
+        );
+
+        if ( $response['available'] ) {
+            $response['message'] = __( 'The company name does not appear in the bundled dataset.', 'company-name-search' );
+        } else {
+            $response['message'] = __( 'The company name already exists in the bundled dataset.', 'company-name-search' );
+        }
+
+        return $response;
+    }
+
+    /**
+     * Performs a search using the OpenCorporates API.
+     *
+     * @param string $name     Company name.
+     * @param array  $settings Plugin settings.
+     *
+     * @return array|WP_Error
+     */
+    protected function search_opencorporates( $name, $settings ) {
+        $endpoint = 'https://api.opencorporates.com/v0.4/companies/search';
+        $limit    = isset( $settings['opencorporates_results_limit'] ) ? (int) $settings['opencorporates_results_limit'] : 10;
+        $limit    = max( 1, min( 100, $limit ) );
+        $args     = array(
+            'q'        => $name,
+            'per_page' => $limit,
+            'order'    => 'score',
+        );
+
+        if ( ! empty( $settings['opencorporates_country_code'] ) ) {
+            $args['country_code'] = $settings['opencorporates_country_code'];
+        }
+
+        $url = add_query_arg( $args, $endpoint );
+
+        $request_args = array(
+            'timeout' => 15,
+            'headers' => array(
+                'Accept' => 'application/json',
+            ),
+        );
+
+        if ( ! empty( $settings['opencorporates_token'] ) ) {
+            $request_args['headers']['Authorization'] = 'Token token=' . $settings['opencorporates_token'];
+        }
+
+        $response = wp_remote_get( $url, $request_args );
+
+        if ( is_wp_error( $response ) ) {
+            return new WP_Error(
+                'company_name_search_http_error',
+                __( 'An error occurred while contacting the OpenCorporates API.', 'company-name-search' ),
+                array( 'status' => 500, 'data' => $response->get_error_message() )
+            );
+        }
+
+        $code = wp_remote_retrieve_response_code( $response );
+
+        if ( 200 !== $code ) {
+            return new WP_Error(
+                'company_name_search_http_status',
+                __( 'Unexpected response received from the OpenCorporates API.', 'company-name-search' ),
+                array( 'status' => $code, 'data' => wp_remote_retrieve_body( $response ) )
+            );
+        }
+
+        $body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+        if ( ! is_array( $body ) ) {
+            return new WP_Error(
+                'company_name_search_invalid_json',
+                __( 'Unable to decode the OpenCorporates API response.', 'company-name-search' ),
+                array( 'status' => 500 )
+            );
+        }
+
+        $raw_companies = array();
+
+        if ( isset( $body['results']['companies'] ) && is_array( $body['results']['companies'] ) ) {
+            $raw_companies = $body['results']['companies'];
+        }
+
+        $matches       = array();
+        $has_exact_hit = false;
+
+        foreach ( $raw_companies as $entry ) {
+            if ( ! isset( $entry['company'] ) || ! is_array( $entry['company'] ) ) {
+                continue;
+            }
+
+            $company = $entry['company'];
+            $name_in_result = isset( $company['name'] ) ? $company['name'] : '';
+
+            if ( '' === $name_in_result ) {
+                continue;
+            }
+
+            if ( 0 === strcasecmp( $name_in_result, $name ) ) {
+                $has_exact_hit = true;
+            }
+
+            $matches[] = array(
+                'name'               => $name_in_result,
+                'company_number'     => isset( $company['company_number'] ) ? $company['company_number'] : '',
+                'jurisdiction_code'  => isset( $company['jurisdiction_code'] ) ? $company['jurisdiction_code'] : '',
+                'status'             => isset( $company['current_status'] ) ? $company['current_status'] : ( isset( $company['status'] ) ? $company['status'] : '' ),
+                'incorporation_date' => isset( $company['incorporation_date'] ) ? $company['incorporation_date'] : '',
+                'source'             => 'OpenCorporates',
+                'registry_url'       => isset( $company['registry_url'] ) ? $company['registry_url'] : '',
+            );
+        }
+
+        $response = array(
+            'query'      => $name,
+            'available'  => ! $has_exact_hit,
+            'source'     => 'opencorporates',
+            'matches'    => $matches,
+            'fetched_at' => current_time( 'mysql' ),
+        );
+
+        if ( $response['available'] ) {
+            $response['message'] = __( 'No exact match was found in OpenCorporates.', 'company-name-search' );
+        } else {
+            $response['message'] = __( 'An exact match was found in OpenCorporates.', 'company-name-search' );
+        }
+
+        if ( isset( $body['results']['total_count'] ) ) {
+            $response['total_results'] = (int) $body['results']['total_count'];
+        }
+
+        return $response;
+    }
+}

--- a/wp-content/plugins/company-name-search/includes/class-company-name-search-plugin.php
+++ b/wp-content/plugins/company-name-search/includes/class-company-name-search-plugin.php
@@ -1,0 +1,416 @@
+<?php
+/**
+ * Core plugin functionality.
+ *
+ * @package Company_Name_Search
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Main plugin class.
+ */
+class Company_Name_Search_Plugin {
+    /**
+     * Option key used to persist settings.
+     */
+    const OPTION_NAME = 'company_name_search_settings';
+
+    /**
+     * Singleton instance.
+     *
+     * @var Company_Name_Search_Plugin|null
+     */
+    protected static $instance = null;
+
+    /**
+     * Flag to ensure hooks are registered only once.
+     *
+     * @var bool
+     */
+    protected $initialized = false;
+
+    /**
+     * API helper instance.
+     *
+     * @var Company_Name_Search_API
+     */
+    protected $api;
+
+    /**
+     * REST controller instance.
+     *
+     * @var Company_Name_Search_REST
+     */
+    protected $rest_controller;
+
+    /**
+     * Returns the plugin singleton instance.
+     *
+     * @return Company_Name_Search_Plugin
+     */
+    public static function instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        if ( ! self::$instance->initialized ) {
+            self::$instance->init();
+            self::$instance->initialized = true;
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Activation callback.
+     */
+    public static function activate() {
+        $settings = get_option( self::OPTION_NAME, array() );
+        update_option( self::OPTION_NAME, wp_parse_args( $settings, self::get_default_settings() ) );
+    }
+
+    /**
+     * Deactivation callback.
+     */
+    public static function deactivate() {
+        // No specific actions are required on deactivation at this time.
+    }
+
+    /**
+     * Retrieves the default plugin settings.
+     *
+     * @return array
+     */
+    public static function get_default_settings() {
+        return array(
+            'data_source'                  => 'local',
+            'opencorporates_token'         => '',
+            'opencorporates_country_code'  => '',
+            'opencorporates_results_limit' => 10,
+            'cache_duration'               => DAY_IN_SECONDS,
+        );
+    }
+
+    /**
+     * Registers WordPress hooks.
+     */
+    protected function init() {
+        $this->api             = new Company_Name_Search_API( $this );
+        $this->rest_controller = new Company_Name_Search_REST( $this->api );
+
+        add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
+        add_action( 'wp_enqueue_scripts', array( $this, 'register_assets' ) );
+        add_shortcode( 'company_name_search', array( $this, 'render_search_shortcode' ) );
+        add_action( 'admin_menu', array( $this, 'register_settings_page' ) );
+        add_action( 'admin_init', array( $this, 'register_settings' ) );
+        add_action( 'rest_api_init', array( $this->rest_controller, 'register_routes' ) );
+    }
+
+    /**
+     * Registers plugin styles and scripts.
+     */
+    public function register_assets() {
+        wp_register_style(
+            'company-name-search',
+            COMPANY_NAME_SEARCH_PLUGIN_URL . 'assets/css/company-name-search.css',
+            array(),
+            COMPANY_NAME_SEARCH_VERSION
+        );
+
+        wp_register_script(
+            'company-name-search',
+            COMPANY_NAME_SEARCH_PLUGIN_URL . 'assets/js/company-name-search.js',
+            array(),
+            COMPANY_NAME_SEARCH_VERSION,
+            true
+        );
+    }
+
+    /**
+     * Enqueues front-end assets and localises script data.
+     */
+    protected function enqueue_frontend_assets() {
+        $this->register_assets();
+
+        wp_enqueue_style( 'company-name-search' );
+        wp_enqueue_script( 'company-name-search' );
+
+        $settings = $this->get_settings();
+
+        wp_localize_script(
+            'company-name-search',
+            'CompanyNameSearch',
+            array(
+                'restUrl'  => esc_url_raw( rest_url( 'company-name-search/v1/check' ) ),
+                'nonce'    => wp_create_nonce( 'wp_rest' ),
+                'settings' => array(
+                    'dataSource' => $settings['data_source'],
+                ),
+                'strings'  => array(
+                    'emptyQuery'   => __( 'Please enter a company name before searching.', 'company-name-search' ),
+                    'loading'      => __( 'Searching…', 'company-name-search' ),
+                    'available'    => __( 'Great news! The name appears to be available.', 'company-name-search' ),
+                    'unavailable'  => __( 'This name is already in use. You may want to try a variation.', 'company-name-search' ),
+                    'noMatches'    => __( 'No similar names were found.', 'company-name-search' ),
+                    'similarTitle' => __( 'Similar names', 'company-name-search' ),
+                    'registryLink' => __( 'Registry', 'company-name-search' ),
+                    'error'        => __( 'We were unable to complete the search. Please try again.', 'company-name-search' ),
+                ),
+            )
+        );
+    }
+
+    /**
+     * Renders the company name search form shortcode.
+     *
+     * @param array  $atts    Shortcode attributes.
+     * @param string $content Shortcode content.
+     *
+     * @return string
+     */
+    public function render_search_shortcode( $atts, $content = '' ) {
+        $atts = shortcode_atts(
+            array(
+                'title' => __( 'Check company name availability', 'company-name-search' ),
+            ),
+            $atts,
+            'company_name_search'
+        );
+
+        $this->enqueue_frontend_assets();
+
+        ob_start();
+        ?>
+        <div class="company-name-search" data-company-name-search>
+            <?php if ( ! empty( $atts['title'] ) ) : ?>
+                <h3 class="company-name-search__title"><?php echo esc_html( $atts['title'] ); ?></h3>
+            <?php endif; ?>
+            <form class="company-name-search__form" novalidate>
+                <label class="screen-reader-text" for="company-name-search-input"><?php esc_html_e( 'Company name', 'company-name-search' ); ?></label>
+                <input
+                    id="company-name-search-input"
+                    type="text"
+                    name="company_name"
+                    class="company-name-search__input"
+                    placeholder="<?php esc_attr_e( 'Enter a company name', 'company-name-search' ); ?>"
+                    required
+                />
+                <button type="submit" class="company-name-search__button"><?php esc_html_e( 'Check availability', 'company-name-search' ); ?></button>
+            </form>
+            <div class="company-name-search__spinner" hidden aria-hidden="true"></div>
+            <div class="company-name-search__results" aria-live="polite"></div>
+        </div>
+        <?php
+
+        return ob_get_clean();
+    }
+
+    /**
+     * Registers the plugin settings page.
+     */
+    public function register_settings_page() {
+        add_options_page(
+            __( 'Company Name Search', 'company-name-search' ),
+            __( 'Company Name Search', 'company-name-search' ),
+            'manage_options',
+            'company-name-search',
+            array( $this, 'render_settings_page' )
+        );
+    }
+
+    /**
+     * Renders the settings page markup.
+     */
+    public function render_settings_page() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Company Name Search Settings', 'company-name-search' ); ?></h1>
+            <form method="post" action="options.php">
+                <?php
+                settings_fields( 'company_name_search' );
+                do_settings_sections( 'company-name-search' );
+                submit_button();
+                ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    /**
+     * Registers plugin settings and fields.
+     */
+    public function register_settings() {
+        register_setting(
+            'company_name_search',
+            self::OPTION_NAME,
+            array( $this, 'sanitize_settings' )
+        );
+
+        add_settings_section(
+            'company_name_search_general',
+            __( 'Search configuration', 'company-name-search' ),
+            array( $this, 'render_settings_section_description' ),
+            'company-name-search'
+        );
+
+        add_settings_field(
+            'data_source',
+            __( 'Data source', 'company-name-search' ),
+            array( $this, 'render_data_source_field' ),
+            'company-name-search',
+            'company_name_search_general'
+        );
+
+        add_settings_field(
+            'opencorporates_token',
+            __( 'OpenCorporates API token', 'company-name-search' ),
+            array( $this, 'render_opencorporates_token_field' ),
+            'company-name-search',
+            'company_name_search_general'
+        );
+
+        add_settings_field(
+            'opencorporates_country_code',
+            __( 'OpenCorporates country code', 'company-name-search' ),
+            array( $this, 'render_opencorporates_country_field' ),
+            'company-name-search',
+            'company_name_search_general'
+        );
+
+        add_settings_field(
+            'opencorporates_results_limit',
+            __( 'Results limit', 'company-name-search' ),
+            array( $this, 'render_results_limit_field' ),
+            'company-name-search',
+            'company_name_search_general'
+        );
+
+        add_settings_field(
+            'cache_duration',
+            __( 'Cache duration (seconds)', 'company-name-search' ),
+            array( $this, 'render_cache_duration_field' ),
+            'company-name-search',
+            'company_name_search_general'
+        );
+    }
+
+    /**
+     * Settings section description renderer.
+     */
+    public function render_settings_section_description() {
+        echo '<p>' . esc_html__( 'Configure how the plugin performs company name availability checks.', 'company-name-search' ) . '</p>';
+    }
+
+    /**
+     * Renders the data source field.
+     */
+    public function render_data_source_field() {
+        $settings    = $this->get_settings();
+        $data_source = isset( $settings['data_source'] ) ? $settings['data_source'] : 'local';
+        ?>
+        <fieldset>
+            <label>
+                <input type="radio" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[data_source]" value="local" <?php checked( 'local', $data_source ); ?> />
+                <?php esc_html_e( 'Use bundled sample data (no external requests).', 'company-name-search' ); ?>
+            </label>
+            <br />
+            <label>
+                <input type="radio" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[data_source]" value="opencorporates" <?php checked( 'opencorporates', $data_source ); ?> />
+                <?php esc_html_e( 'Query the OpenCorporates API (requires internet access).', 'company-name-search' ); ?>
+            </label>
+        </fieldset>
+        <?php
+    }
+
+    /**
+     * Renders the OpenCorporates token field.
+     */
+    public function render_opencorporates_token_field() {
+        $settings = $this->get_settings();
+        $token    = isset( $settings['opencorporates_token'] ) ? $settings['opencorporates_token'] : '';
+        ?>
+        <input type="text" class="regular-text" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[opencorporates_token]" value="<?php echo esc_attr( $token ); ?>" />
+        <p class="description"><?php esc_html_e( 'Optional. Provide an API token if your OpenCorporates plan requires one.', 'company-name-search' ); ?></p>
+        <?php
+    }
+
+    /**
+     * Renders the OpenCorporates country code field.
+     */
+    public function render_opencorporates_country_field() {
+        $settings      = $this->get_settings();
+        $country_code  = isset( $settings['opencorporates_country_code'] ) ? $settings['opencorporates_country_code'] : '';
+        ?>
+        <input type="text" class="regular-text" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[opencorporates_country_code]" value="<?php echo esc_attr( $country_code ); ?>" />
+        <p class="description"><?php esc_html_e( 'Optional two-letter country code to limit OpenCorporates results (for example: us, gb, au).', 'company-name-search' ); ?></p>
+        <?php
+    }
+
+    /**
+     * Renders the OpenCorporates results limit field.
+     */
+    public function render_results_limit_field() {
+        $settings = $this->get_settings();
+        $limit    = isset( $settings['opencorporates_results_limit'] ) ? (int) $settings['opencorporates_results_limit'] : 10;
+        ?>
+        <input type="number" min="1" max="50" step="1" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[opencorporates_results_limit]" value="<?php echo esc_attr( $limit ); ?>" />
+        <p class="description"><?php esc_html_e( 'Maximum number of records to retrieve from OpenCorporates (default 10).', 'company-name-search' ); ?></p>
+        <?php
+    }
+
+    /**
+     * Renders the cache duration field.
+     */
+    public function render_cache_duration_field() {
+        $settings = $this->get_settings();
+        $cache    = isset( $settings['cache_duration'] ) ? (int) $settings['cache_duration'] : DAY_IN_SECONDS;
+        ?>
+        <input type="number" min="0" step="60" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[cache_duration]" value="<?php echo esc_attr( $cache ); ?>" />
+        <p class="description"><?php esc_html_e( 'How long to cache search results (in seconds). Set to 0 to disable caching.', 'company-name-search' ); ?></p>
+        <?php
+    }
+
+
+    /**
+     * Loads the plugin text domain.
+     */
+    public function load_textdomain() {
+        load_plugin_textdomain( 'company-name-search', false, dirname( plugin_basename( COMPANY_NAME_SEARCH_PLUGIN_FILE ) ) . '/languages' );
+    }
+
+    /**
+     * Sanitises and validates settings before saving.
+     *
+     * @param array $input Raw settings.
+     *
+     * @return array
+     */
+    public function sanitize_settings( $input ) {
+        $defaults  = self::get_default_settings();
+        $sanitized = wp_parse_args( is_array( $input ) ? $input : array(), $defaults );
+
+        $sanitized['data_source']                  = in_array( $sanitized['data_source'], array( 'local', 'opencorporates' ), true ) ? $sanitized['data_source'] : 'local';
+        $sanitized['opencorporates_token']         = sanitize_text_field( $sanitized['opencorporates_token'] );
+        $sanitized['opencorporates_country_code']  = sanitize_text_field( $sanitized['opencorporates_country_code'] );
+        $sanitized['opencorporates_results_limit'] = max( 1, min( 50, (int) $sanitized['opencorporates_results_limit'] ) );
+        $sanitized['cache_duration']               = max( 0, (int) $sanitized['cache_duration'] );
+
+        return $sanitized;
+    }
+
+    /**
+     * Retrieves plugin settings merged with defaults.
+     *
+     * @return array
+     */
+    public function get_settings() {
+        return wp_parse_args( get_option( self::OPTION_NAME, array() ), self::get_default_settings() );
+    }
+}

--- a/wp-content/plugins/company-name-search/includes/class-company-name-search-rest.php
+++ b/wp-content/plugins/company-name-search/includes/class-company-name-search-rest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * REST API controller for the company name search endpoint.
+ *
+ * @package Company_Name_Search
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Registers REST routes.
+ */
+class Company_Name_Search_REST {
+    /**
+     * API helper instance.
+     *
+     * @var Company_Name_Search_API
+     */
+    protected $api;
+
+    /**
+     * Constructor.
+     *
+     * @param Company_Name_Search_API $api API helper.
+     */
+    public function __construct( Company_Name_Search_API $api ) {
+        $this->api = $api;
+    }
+
+    /**
+     * Registers REST routes.
+     */
+    public function register_routes() {
+        register_rest_route(
+            'company-name-search/v1',
+            '/check',
+            array(
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => array( $this, 'handle_search' ),
+                'permission_callback' => '__return_true',
+                'args'                => array(
+                    'name' => array(
+                        'description'       => __( 'Company name to search for.', 'company-name-search' ),
+                        'required'          => true,
+                        'sanitize_callback' => array( $this, 'sanitize_name' ),
+                    ),
+                ),
+            )
+        );
+    }
+
+    /**
+     * Sanitises the search name parameter.
+     *
+     * @param string $value Raw value.
+     *
+     * @return string
+     */
+    public function sanitize_name( $value ) {
+        return sanitize_text_field( $value );
+    }
+
+    /**
+     * Handles the REST request.
+     *
+     * @param WP_REST_Request $request Request object.
+     *
+     * @return WP_REST_Response|WP_Error
+     */
+    public function handle_search( WP_REST_Request $request ) {
+        $name = $request->get_param( 'name' );
+
+        if ( '' === trim( (string) $name ) ) {
+            return new WP_Error(
+                'company_name_search_empty',
+                __( 'Please provide a company name to search.', 'company-name-search' ),
+                array( 'status' => 400 )
+            );
+        }
+
+        $result = $this->api->search( $name );
+
+        if ( is_wp_error( $result ) ) {
+            return $result;
+        }
+
+        return rest_ensure_response( $result );
+    }
+}


### PR DESCRIPTION
## Summary
- add a WordPress plugin skeleton that boots the Company Name Availability Search feature
- implement admin settings, REST endpoint, and data source helpers to support bundled data or OpenCorporates queries
- provide front-end assets, sample data, and documentation for using the `[company_name_search]` shortcode

## Testing
- `for file in $(find wp-content/plugins/company-name-search -name '*.php'); do php -l "$file"; done`

------
https://chatgpt.com/codex/tasks/task_e_68caa0a1f52c8320804b452c59e039ef